### PR TITLE
Prepare for release to crates.io

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,4 +9,4 @@ bitflags = "1.0"
 libc = "0.2.65"
 nix = "0.13"
 thiserror = "1.0.4"
-userfaultfd-sys = { path = "userfaultfd-sys" }
+userfaultfd-sys = { version = "=0.1.0", path = "userfaultfd-sys" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,10 @@ name = "userfaultfd"
 version = "0.1.0"
 authors = ["Adam C. Foltzer <acfoltzer@fastly.com>"]
 edition = "2018"
+license = "MIT OR Apache-2.0"
+description = "Rust bindings for the Linux userfaultfd functionality"
+repository = "https://github.com/fastly/userfaultfd-rs"
+readme = "README.md"
 
 [dependencies]
 bitflags = "1.0"

--- a/linux-version/Cargo.toml
+++ b/linux-version/Cargo.toml
@@ -3,6 +3,7 @@ name = "linux-version"
 version = "0.1.0"
 authors = ["Adam C. Foltzer <acfoltzer@fastly.com>"]
 edition = "2018"
+license = "MIT OR Apache-2.0"
 
 build = "build.rs"
 

--- a/userfaultfd-sys/Cargo.toml
+++ b/userfaultfd-sys/Cargo.toml
@@ -3,6 +3,7 @@ name = "userfaultfd-sys"
 version = "0.1.0"
 authors = ["Adam C. Foltzer <acfoltzer@fastly.com>"]
 edition = "2018"
+license = "MIT OR Apache-2.0"
 
 build = "build.rs"
 

--- a/userfaultfd-sys/Cargo.toml
+++ b/userfaultfd-sys/Cargo.toml
@@ -12,4 +12,4 @@ cfg-if = "0.1"
 [build-dependencies]
 bindgen = "0.51"
 cc = "1.0"
-linux-version = { path = "../linux-version" }
+linux-version = { version = "=0.1.0", path = "../linux-version" }


### PR DESCRIPTION
Updates the Cargo.toml files to specify version for dependent local crates.
Also adds some details to the Cargo.toml of the top level package.