### PR TITLE
Release 0.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,3 @@
+### 0.1.0 (2020-04-07)
+
+- Initial public release of userfaultfd-rs.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -352,18 +352,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "userfaultfd"
-version = "0.1.0"
+version = "0.2.0-dev"
 dependencies = [
  "bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.68 (registry+https://github.com/rust-lang/crates.io-index)",
  "nix 0.13.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "thiserror 1.0.14 (registry+https://github.com/rust-lang/crates.io-index)",
- "userfaultfd-sys 0.1.0",
+ "userfaultfd-sys 0.2.0-dev",
 ]
 
 [[package]]
 name = "userfaultfd-sys"
-version = "0.1.0"
+version = "0.2.0-dev"
 dependencies = [
  "bindgen 0.51.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "cc 1.0.28 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "userfaultfd"
-version = "0.1.0"
+version = "0.2.0-dev"
 authors = ["Adam C. Foltzer <acfoltzer@fastly.com>"]
 edition = "2018"
 license = "MIT OR Apache-2.0"
@@ -13,4 +13,4 @@ bitflags = "1.0"
 libc = "0.2.65"
 nix = "0.13"
 thiserror = "1.0.4"
-userfaultfd-sys = { version = "=0.1.0", path = "userfaultfd-sys" }
+userfaultfd-sys = { version = "=0.2.0-dev", path = "userfaultfd-sys" }

--- a/linux-version/Cargo.toml
+++ b/linux-version/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 authors = ["Adam C. Foltzer <acfoltzer@fastly.com>"]
 edition = "2018"
 license = "MIT OR Apache-2.0"
+description = "Package for detecting the version of the linux kernel a program is being run on."
 
 build = "build.rs"
 

--- a/userfaultfd-sys/Cargo.toml
+++ b/userfaultfd-sys/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 authors = ["Adam C. Foltzer <acfoltzer@fastly.com>"]
 edition = "2018"
 license = "MIT OR Apache-2.0"
+description = "Low-level bindings for userfaultfd functionality on Linux."
 
 build = "build.rs"
 

--- a/userfaultfd-sys/Cargo.toml
+++ b/userfaultfd-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "userfaultfd-sys"
-version = "0.1.0"
+version = "0.2.0-dev"
 authors = ["Adam C. Foltzer <acfoltzer@fastly.com>"]
 edition = "2018"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
This is the initial public release of userfaultfd-rs. 

I'm roughly following the same [release style](https://bytecodealliance.github.io/lucet/versioning_releasing.html) that we do for Lucet. So, once this gets approval, I will do the following:

* Release to crates.io
* Tag the release
* Bump packages to 0.2.0-dev
* Merge this PR