### PR TITLE
Bump bindgen version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "userfaultfd"
-version = "0.2.2-dev"
+version = "0.2.2"
 authors = ["Adam C. Foltzer <acfoltzer@fastly.com>"]
 edition = "2018"
 license = "MIT OR Apache-2.0"
@@ -13,4 +13,4 @@ bitflags = "1.0"
 libc = "0.2.65"
 nix = "0.17"
 thiserror = "1.0.4"
-userfaultfd-sys = { path = "userfaultfd-sys", version = "0.2.2-dev" }
+userfaultfd-sys = { path = "userfaultfd-sys", version = "0.2.2" }

--- a/userfaultfd-sys/Cargo.toml
+++ b/userfaultfd-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "userfaultfd-sys"
-version = "0.2.2-dev"
+version = "0.2.2"
 authors = ["Adam C. Foltzer <acfoltzer@fastly.com>"]
 edition = "2018"
 license = "MIT OR Apache-2.0"

--- a/userfaultfd-sys/Cargo.toml
+++ b/userfaultfd-sys/Cargo.toml
@@ -12,7 +12,7 @@ build = "build.rs"
 cfg-if = "0.1"
 
 [build-dependencies]
-bindgen = { version = "0.51", default-features = false }
+bindgen = { version = "0.57", default-features = false, features = ["runtime"]  }
 cc = "1.0"
 
 [features]


### PR DESCRIPTION
Attempting to consume this package from one which uses a later version of bindgen, and it seems like the differing version of clang-sys dependencies don't play nicely together. Not entirely sure why possibly/probably due to linking against the system libclang library?... Assuming we need to bump the version of bindgen.

This is the error:

```
cargo build \
    --release \
    --target="aarch64-unknown-linux-musl" \
    --manifest-path="memory-manager/Cargo.toml" \
    --target-dir="/workplace/jgowans/build-aarch64/memory-manager"
    Updating crates.io index
error: failed to select a version for `clang-sys`.
    ... required by package `bindgen v0.56.0`
    ... which is depended on by `memory-manager v0.1.0 (/workplace/jgowans/memory-manager/memory-manager)`
versions that meet the requirements `>=1.0.0, <2.0.0` are: 1.0.3, 1.0.2, 1.0.1, 1.0.0

the package `clang-sys` links to the native library `clang`, but it conflicts with a previous package which links to `clang` as well:
package `clang-sys v0.28.0`
    ... which is depended on by `bindgen v0.51.0`
    ... which is depended on by `userfaultfd-sys v0.2.1`
    ... which is depended on by `userfaultfd v0.2.1`
    ... which is depended on by `memory-manager v0.1.0 (/workplace/jgowans/memory-manager/memory-manager)`

failed to select a version for `clang-sys` which could resolve this conflict
Makefile.dev:32: recipe for target 'build' failed
make: *** [build] Error 101
```