### PR TITLE
Implement `Uffd::read_events`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ### Unreleased
 
+- Added `Uffd::read_events` that can read multiple events from the userfaultfd file descriptor.
+
 ### 0.3.1 (2021-02-17)
 
 - Added support for the `UFFD_FEATURE_THREAD_ID` flag when compiled with the `linux4_14` Cargo

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,6 +1,6 @@
 use crate::IoctlFlags;
-use thiserror::Error;
 use nix::errno::Errno;
+use thiserror::Error;
 
 pub type Result<T> = std::result::Result<T, Error>;
 


### PR DESCRIPTION
This commit implements `Uffd::read_events` that users can call to read multiple
events into a caller-supplied buffer.

An iterator is returned that reads the `Event` objects out of the buffer for
the events that were read.

The implementation of `read_event` was updated as a call to `read_events`,
supplying a buffer large enough for a single event.

Three tests were added: `read_event`, `nonblocking_read_event`, and `read_events`.
The `read_events` test is inherently racy, but is implemented to help minimize
hitting the race condition.