### PR TITLE
Check for the correct EOF value from read(2).

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -348,11 +348,8 @@ impl Uffd {
         let count = match read(self.as_raw_fd(), buf) {
             Err(e) if e.as_errno() == Some(Errno::EAGAIN) => 0,
             Err(e) => return Err(Error::SystemError(e)),
+            Ok(0) => return Err(Error::ReadEof),
             Ok(bytes_read) => {
-                if bytes_read == libc::EOF as usize {
-                    return Err(Error::ReadEof);
-                }
-
                 let remainder = bytes_read % MSG_SIZE;
                 if remainder != 0 {
                     return Err(Error::IncompleteMsg {


### PR DESCRIPTION
read(2) returns 0 on EOF, rather than `libc::EOF`.

This also matches the EOF check done in the userfaultfd [example].

[example]: https://man7.org/linux/man-pages/man2/userfaultfd.2.html#EXAMPLES

I haven't observed EOF on a userfaultfd occurring in an actual use; this is
just something I noticed while reading the code.