### PR TITLE
userfaultfd: update version to 0.4.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "userfaultfd"
-version = "0.3.3"
+version = "0.4.0"
 authors = ["Adam C. Foltzer <acfoltzer@fastly.com>"]
 edition = "2018"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
No code changes since release 0.3.3. However, 0.3.3 was semver-incompatible with 0.3.2, so we need to publish it as 0.4.0 and then yank 0.3.3.

Fixes #23 