### PR TITLE
release 0.4.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "userfaultfd"
-version = "0.4.1"
+version = "0.4.2"
 authors = ["Adam C. Foltzer <acfoltzer@fastly.com>"]
 edition = "2018"
 license = "MIT OR Apache-2.0"
@@ -14,7 +14,7 @@ cfg-if = "^1.0.0"
 libc = "0.2.65"
 nix = "0.23"
 thiserror = "1.0.4"
-userfaultfd-sys = { path = "userfaultfd-sys", version = "^0.3.0" }
+userfaultfd-sys = { path = "userfaultfd-sys", version = "^0.4.0" }
 
 [features]
 default = []

--- a/userfaultfd-sys/Cargo.toml
+++ b/userfaultfd-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "userfaultfd-sys"
-version = "0.3.1"
+version = "0.4.0"
 authors = ["Adam C. Foltzer <acfoltzer@fastly.com>"]
 edition = "2018"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
userfaultfd-sys goes from 0.3.1 -> 0.4.0: minor bump is required
userfaultfd goes from 0.4.1 -> 0.4.2: builder adds an additional method, so only patch bump is required