### PR TITLE
Define `UFFDIO_COPY_MODE_WP`, and the `UFFDIO_*` ioctl constants.

### DIFF
--- a/userfaultfd-sys/src/consts.c
+++ b/userfaultfd-sys/src/consts.c
@@ -1,4 +1,5 @@
 #include <linux/types.h>
+#include <linux/ioctl.h>
 #include <linux/userfaultfd.h>
 
 #ifdef UFFD_API
@@ -33,7 +34,38 @@ const __u64 _const_UFFDIO_REGISTER_MODE_WP = UFFDIO_REGISTER_MODE_WP;
 const __u64 _const_UFFDIO_COPY_MODE_DONTWAKE = UFFDIO_COPY_MODE_DONTWAKE;
 #endif
 
+#ifdef UFFDIO_COPY_MODE_WP
+const __u64 _const_UFFDIO_COPY_MODE_WP = UFFDIO_COPY_MODE_WP;
+#endif
+
 #ifdef UFFDIO_ZEROPAGE_MODE_DONTWAKE
 const __u64 _const_UFFDIO_ZEROPAGE_MODE_DONTWAKE = UFFDIO_ZEROPAGE_MODE_DONTWAKE;
 #endif
 
+#ifdef UFFDIO_API
+const __u32 _const_UFFDIO_API = UFFDIO_API;
+#endif
+
+#ifdef UFFDIO_REGISTER
+const __u32 _const_UFFDIO_REGISTER = UFFDIO_REGISTER;
+#endif
+
+#ifdef UFFDIO_UNREGISTER
+const __u32 _const_UFFDIO_UNREGISTER = UFFDIO_UNREGISTER;
+#endif
+
+#ifdef UFFDIO_WAKE
+const __u32 _const_UFFDIO_WAKE = UFFDIO_WAKE;
+#endif
+
+#ifdef UFFDIO_COPY
+const __u32 _const_UFFDIO_COPY = UFFDIO_COPY;
+#endif
+
+#ifdef UFFDIO_ZEROPAGE
+const __u32 _const_UFFDIO_ZEROPAGE = UFFDIO_ZEROPAGE;
+#endif
+
+#ifdef UFFDIO_WRITEPROTECT
+const __u32 _const_UFFDIO_WRITEPROTECT = UFFDIO_WRITEPROTECT;
+#endif

--- a/userfaultfd-sys/src/linux4_11.rs
+++ b/userfaultfd-sys/src/linux4_11.rs
@@ -19,8 +19,17 @@ pub const UFFDIO_REGISTER_MODE_MISSING: u64 = 1 << 0;
 pub const UFFDIO_REGISTER_MODE_WP: u64 = 1 << 1;
 
 pub const UFFDIO_COPY_MODE_DONTWAKE: u64 = 1 << 0;
+pub const UFFDIO_COPY_MODE_WP: u64 = 1 << 1;
 
 pub const UFFDIO_ZEROPAGE_MODE_DONTWAKE: u64 = 1 << 0;
+
+pub const UFFDIO_API: u32 = 0xc018aa3f;
+pub const UFFDIO_REGISTER: u32 = 0xc020aa00;
+pub const UFFDIO_UNREGISTER: u32 = 0x8010aa01;
+pub const UFFDIO_WAKE: u32 = 0x8010aa02;
+pub const UFFDIO_COPY: u32 = 0xc028aa03;
+pub const UFFDIO_ZEROPAGE: u32 = 0xc020aa04;
+pub const UFFDIO_WRITEPROTECT: u32 = 0xc018aa06;
 
 #[cfg(test)]
 mod const_tests {
@@ -34,7 +43,15 @@ mod const_tests {
         static _const_UFFDIO_REGISTER_MODE_MISSING: u64;
         static _const_UFFDIO_REGISTER_MODE_WP: u64;
         static _const_UFFDIO_COPY_MODE_DONTWAKE: u64;
+        static _const_UFFDIO_COPY_MODE_WP: u64;
         static _const_UFFDIO_ZEROPAGE_MODE_DONTWAKE: u64;
+        static _const_UFFDIO_API: u32;
+        static _const_UFFDIO_REGISTER: u32;
+        static _const_UFFDIO_UNREGISTER: u32;
+        static _const_UFFDIO_WAKE: u32;
+        static _const_UFFDIO_COPY: u32;
+        static _const_UFFDIO_ZEROPAGE: u32;
+        static _const_UFFDIO_WRITEPROTECT: u32;
     }
 
     #[test]
@@ -63,8 +80,25 @@ mod const_tests {
                 "UFFDIO_COPY_MODE_DONTWAKE"
             );
             assert_eq!(
+                UFFDIO_COPY_MODE_WP, _const_UFFDIO_COPY_MODE_WP,
+                "UFFDIO_COPY_MODE_WP"
+            );
+            assert_eq!(
                 UFFDIO_ZEROPAGE_MODE_DONTWAKE, _const_UFFDIO_ZEROPAGE_MODE_DONTWAKE,
                 "UFFDIO_ZEROPAGE_MODE_DONTWAKE"
+            );
+            assert_eq!(UFFDIO_API, _const_UFFDIO_API, "UFFDIO_API");
+            assert_eq!(UFFDIO_REGISTER, _const_UFFDIO_REGISTER, "UFFDIO_REGISTER");
+            assert_eq!(
+                UFFDIO_UNREGISTER, _const_UFFDIO_UNREGISTER,
+                "UFFDIO_UNREGISTER"
+            );
+            assert_eq!(UFFDIO_WAKE, _const_UFFDIO_WAKE, "UFFDIO_WAKE");
+            assert_eq!(UFFDIO_COPY, _const_UFFDIO_COPY, "UFFDIO_COPY");
+            assert_eq!(UFFDIO_ZEROPAGE, _const_UFFDIO_ZEROPAGE, "UFFDIO_ZEROPAGE");
+            assert_eq!(
+                UFFDIO_WRITEPROTECT, _const_UFFDIO_WRITEPROTECT,
+                "UFFDIO_WRITEPROTECT"
             );
         }
     }

--- a/userfaultfd-sys/src/linux4_14.rs
+++ b/userfaultfd-sys/src/linux4_14.rs
@@ -22,8 +22,17 @@ pub const UFFDIO_REGISTER_MODE_MISSING: u64 = 1 << 0;
 pub const UFFDIO_REGISTER_MODE_WP: u64 = 1 << 1;
 
 pub const UFFDIO_COPY_MODE_DONTWAKE: u64 = 1 << 0;
+pub const UFFDIO_COPY_MODE_WP: u64 = 1 << 1;
 
 pub const UFFDIO_ZEROPAGE_MODE_DONTWAKE: u64 = 1 << 0;
+
+pub const UFFDIO_API: u32 = 0xc018aa3f;
+pub const UFFDIO_REGISTER: u32 = 0xc020aa00;
+pub const UFFDIO_UNREGISTER: u32 = 0x8010aa01;
+pub const UFFDIO_WAKE: u32 = 0x8010aa02;
+pub const UFFDIO_COPY: u32 = 0xc028aa03;
+pub const UFFDIO_ZEROPAGE: u32 = 0xc020aa04;
+pub const UFFDIO_WRITEPROTECT: u32 = 0xc018aa06;
 
 #[cfg(test)]
 mod const_tests {
@@ -38,7 +47,15 @@ mod const_tests {
         static _const_UFFDIO_REGISTER_MODE_MISSING: u64;
         static _const_UFFDIO_REGISTER_MODE_WP: u64;
         static _const_UFFDIO_COPY_MODE_DONTWAKE: u64;
+        static _const_UFFDIO_COPY_MODE_WP: u64;
         static _const_UFFDIO_ZEROPAGE_MODE_DONTWAKE: u64;
+        static _const_UFFDIO_API: u32;
+        static _const_UFFDIO_REGISTER: u32;
+        static _const_UFFDIO_UNREGISTER: u32;
+        static _const_UFFDIO_WAKE: u32;
+        static _const_UFFDIO_COPY: u32;
+        static _const_UFFDIO_ZEROPAGE: u32;
+        static _const_UFFDIO_WRITEPROTECT: u32;
     }
 
     #[test]
@@ -71,8 +88,25 @@ mod const_tests {
                 "UFFDIO_COPY_MODE_DONTWAKE"
             );
             assert_eq!(
+                UFFDIO_COPY_MODE_WP, _const_UFFDIO_COPY_MODE_WP,
+                "UFFDIO_COPY_MODE_WP"
+            );
+            assert_eq!(
                 UFFDIO_ZEROPAGE_MODE_DONTWAKE, _const_UFFDIO_ZEROPAGE_MODE_DONTWAKE,
                 "UFFDIO_ZEROPAGE_MODE_DONTWAKE"
+            );
+            assert_eq!(UFFDIO_API, _const_UFFDIO_API, "UFFDIO_API");
+            assert_eq!(UFFDIO_REGISTER, _const_UFFDIO_REGISTER, "UFFDIO_REGISTER");
+            assert_eq!(
+                UFFDIO_UNREGISTER, _const_UFFDIO_UNREGISTER,
+                "UFFDIO_UNREGISTER"
+            );
+            assert_eq!(UFFDIO_WAKE, _const_UFFDIO_WAKE, "UFFDIO_WAKE");
+            assert_eq!(UFFDIO_COPY, _const_UFFDIO_COPY, "UFFDIO_COPY");
+            assert_eq!(UFFDIO_ZEROPAGE, _const_UFFDIO_ZEROPAGE, "UFFDIO_ZEROPAGE");
+            assert_eq!(
+                UFFDIO_WRITEPROTECT, _const_UFFDIO_WRITEPROTECT,
+                "UFFDIO_WRITEPROTECT"
             );
         }
     }

--- a/userfaultfd-sys/src/linux5_7.rs
+++ b/userfaultfd-sys/src/linux5_7.rs
@@ -24,9 +24,18 @@ pub const UFFD_API_RANGE_IOCTLS_BASIC: u64 = 1 << _UFFDIO_WAKE | 1 << _UFFDIO_CO
 pub const UFFDIO_REGISTER_MODE_MISSING: u64 = 1 << 0;
 pub const UFFDIO_REGISTER_MODE_WP: u64 = 1 << 1;
 pub const UFFDIO_COPY_MODE_DONTWAKE: u64 = 1 << 0;
+pub const UFFDIO_COPY_MODE_WP: u64 = 1 << 1;
 pub const UFFDIO_ZEROPAGE_MODE_DONTWAKE: u64 = 1 << 0;
 pub const UFFDIO_WRITEPROTECT_MODE_WP: u64 = 1 << 0;
 pub const UFFDIO_WRITEPROTECT_MODE_DONTWAKE: u64 = 1 << 1;
+
+pub const UFFDIO_API: u32 = 0xc018aa3f;
+pub const UFFDIO_REGISTER: u32 = 0xc020aa00;
+pub const UFFDIO_UNREGISTER: u32 = 0x8010aa01;
+pub const UFFDIO_WAKE: u32 = 0x8010aa02;
+pub const UFFDIO_COPY: u32 = 0xc028aa03;
+pub const UFFDIO_ZEROPAGE: u32 = 0xc020aa04;
+pub const UFFDIO_WRITEPROTECT: u32 = 0xc018aa06;
 
 #[cfg(test)]
 mod const_tests {
@@ -41,7 +50,15 @@ mod const_tests {
         static _const_UFFDIO_REGISTER_MODE_MISSING: u64;
         static _const_UFFDIO_REGISTER_MODE_WP: u64;
         static _const_UFFDIO_COPY_MODE_DONTWAKE: u64;
+        static _const_UFFDIO_COPY_MODE_WP: u64;
         static _const_UFFDIO_ZEROPAGE_MODE_DONTWAKE: u64;
+        static _const_UFFDIO_API: u32;
+        static _const_UFFDIO_REGISTER: u32;
+        static _const_UFFDIO_UNREGISTER: u32;
+        static _const_UFFDIO_WAKE: u32;
+        static _const_UFFDIO_COPY: u32;
+        static _const_UFFDIO_ZEROPAGE: u32;
+        static _const_UFFDIO_WRITEPROTECT: u32;
     }
 
     #[test]
@@ -74,8 +91,25 @@ mod const_tests {
                 "UFFDIO_COPY_MODE_DONTWAKE"
             );
             assert_eq!(
+                UFFDIO_COPY_MODE_WP, _const_UFFDIO_COPY_MODE_WP,
+                "UFFDIO_COPY_MODE_WP"
+            );
+            assert_eq!(
                 UFFDIO_ZEROPAGE_MODE_DONTWAKE, _const_UFFDIO_ZEROPAGE_MODE_DONTWAKE,
                 "UFFDIO_ZEROPAGE_MODE_DONTWAKE"
+            );
+            assert_eq!(UFFDIO_API, _const_UFFDIO_API, "UFFDIO_API");
+            assert_eq!(UFFDIO_REGISTER, _const_UFFDIO_REGISTER, "UFFDIO_REGISTER");
+            assert_eq!(
+                UFFDIO_UNREGISTER, _const_UFFDIO_UNREGISTER,
+                "UFFDIO_UNREGISTER"
+            );
+            assert_eq!(UFFDIO_WAKE, _const_UFFDIO_WAKE, "UFFDIO_WAKE");
+            assert_eq!(UFFDIO_COPY, _const_UFFDIO_COPY, "UFFDIO_COPY");
+            assert_eq!(UFFDIO_ZEROPAGE, _const_UFFDIO_ZEROPAGE, "UFFDIO_ZEROPAGE");
+            assert_eq!(
+                UFFDIO_WRITEPROTECT, _const_UFFDIO_WRITEPROTECT,
+                "UFFDIO_WRITEPROTECT"
             );
         }
     }


### PR DESCRIPTION
Define `UFFDIO_COPY_MODE_WP`, similar to `UFFDIO_COPY_MODE_DONTWAKE`.

And define the `UFFDIO_*` ioctl request code macros.

As with other constants in userfaultfd-sys, this hard-codes magic
numbers for these constants, and adds tests to check their values
against the values seen by C.