### PR TITLE
bump userfaultfd-sys to 0.4.1

### DIFF
--- a/userfaultfd-sys/Cargo.toml
+++ b/userfaultfd-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "userfaultfd-sys"
-version = "0.4.0"
+version = "0.4.1"
 authors = ["Adam C. Foltzer <acfoltzer@fastly.com>"]
 edition = "2018"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
only addition is 682a29ba78b9e2df8189fad1586bc11a771fdd5a, which adds additional constants.