### PR TITLE
Fix linux4_14 feature flags

### DIFF
--- a/src/event.rs
+++ b/src/event.rs
@@ -2,7 +2,7 @@ use crate::error::{Error, Result};
 use crate::raw;
 use crate::Uffd;
 use libc::c_void;
-#[cfg(linux4_14)]
+#[cfg(feature = "linux4_14")]
 use nix::unistd::Pid;
 use std::os::unix::io::{FromRawFd, RawFd};
 
@@ -41,7 +41,7 @@ pub enum Event {
         /// necessarily point to a real thread.
         ///
         /// This requires this crate to be compiled with the `linux4_14` feature.
-        #[cfg(linux4_14)]
+        #[cfg(feature = "linux4_14")]
         thread_id: Pid,
     },
     /// Generated when the faulting process invokes `fork(2)` (or `clone(2)` without the `CLONE_VM`
@@ -99,13 +99,18 @@ impl Event {
                 } else {
                     ReadWrite::Write
                 };
-                #[cfg(linux4_14)]
-                let thread_id = Pid::from_raw(unsafe { pagefault.feat.ptid });
+                // Converting the ptid to i32 is safe because the maximum pid in
+                // Linux is 2^22, which is about 4 million.
+                //
+                // Reference:
+                //   https://github.com/torvalds/linux/blob/2d338201d5311bcd79d42f66df4cecbcbc5f4f2c/include/linux/threads.h
+                #[cfg(feature = "linux4_14")]
+                let thread_id = Pid::from_raw(unsafe { pagefault.feat.ptid } as i32);
                 Ok(Event::Pagefault {
                     kind,
                     rw,
                     addr: pagefault.address as *mut c_void,
-                    #[cfg(linux4_14)]
+                    #[cfg(feature = "linux4_14")]
                     thread_id,
                 })
             }


### PR DESCRIPTION
Before this change, code intended for the `linux4_14` feature would not get compiled in as expected. The reason is that the feature flags were not specified in the way Rust expects (this is a common footgun).

This change fixes the `linux4_14` feature flag usage, and safely casts the `ptid` to the expected `nix::unistd::Pid`.