### PR TITLE
Update bindgen to the latest (0.60.1)

### DIFF
--- a/userfaultfd-sys/Cargo.toml
+++ b/userfaultfd-sys/Cargo.toml
@@ -13,7 +13,7 @@ build = "build.rs"
 cfg-if = "0.1"
 
 [build-dependencies]
-bindgen = { version = "^0.59.1", default-features = false, features = ["runtime"]  }
+bindgen = { version = "^0.60.1", default-features = false, features = ["runtime"]  }
 cc = "1.0"
 
 [features]


### PR DESCRIPTION
`cargo test` on userfaultfd-sys fails due to compile error: reference to packed field is unaligned. The error was introduced recently (https://github.com/rust-lang/rust/issues/82523) and the latest bindgen supports it.

```
$ cargo -V
cargo 1.65.0-nightly (6da726708 2022-08-23)
```