### PR TITLE
Update cfg-if to the latest (1.0.0)

### DIFF
--- a/userfaultfd-sys/Cargo.toml
+++ b/userfaultfd-sys/Cargo.toml
@@ -10,7 +10,7 @@ repository = "https://github.com/fastly/userfaultfd-rs"
 build = "build.rs"
 
 [dependencies]
-cfg-if = "0.1"
+cfg-if = "^1.0.0"
 
 [build-dependencies]
 bindgen = { version = "^0.59.1", default-features = false, features = ["runtime"]  }


### PR DESCRIPTION
This also match the version of cfg-if between userfaultfd and userfaultfd-sys packages.