### PR TITLE
Add PartiallyCopied error for copy()

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -16,6 +16,10 @@ pub enum Error {
     #[error("Copy failed")]
     CopyFailed(Errno),
 
+    /// Copy ioctl failure with copied length.
+    #[error("Copy partially succeeded")]
+    PartiallyCopied(usize),
+
     /// Failure to read a full `uffd_msg` struct from the underlying file descriptor.
     #[error("Incomplete uffd_msg; read only {read}/{expected} bytes")]
     IncompleteMsg { read: usize, expected: usize },


### PR DESCRIPTION
UFFDIO_COPY returns EAGAIN when "The number of bytes copied (i.e., the value returned in the copy field) does not equal the value that was specified in the len field." (the man page:
https://man7.org/linux/man-pages/man2/ioctl_userfaultfd.2.html)

We need the copy field of struct uffdio_copy to retry copying.