### PR TITLE
release userfaultfd 0.5.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "userfaultfd"
-version = "0.4.2"
+version = "0.5.0"
 authors = ["Adam C. Foltzer <acfoltzer@fastly.com>"]
 edition = "2018"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
This adds an enum variant to `Error`, so its a minor version bump.

Changelog since 0.4.2:
#29 Define UFFDIO_COPY_MODE_WP, and the UFFDIO_* ioctl constants
#34 Update bindgen to the latest (0.60.1)
#35 Update cfg-if to the latest (1.0.0) 
#36 Add PartiallyCopied error for copy() 
#33 Fix linux4_14 feature flags