### PR TITLE
userfaultfd-sys: release 0.4.2

### DIFF
--- a/userfaultfd-sys/Cargo.toml
+++ b/userfaultfd-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "userfaultfd-sys"
-version = "0.4.1"
+version = "0.4.2"
 authors = ["Adam C. Foltzer <acfoltzer@fastly.com>"]
 edition = "2018"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
This is a patch release, the only changes are to deps which do not change the public API:

#35 upgrades cfg-if to 1.0.0
#34 upgrades bindgen to 0.60.1

This should have been done as part of #37 but I missed it.