### PR TITLE
Allow static and dynamic linking

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,12 +14,16 @@ cfg-if = "^1.0.0"
 libc = "0.2.65"
 nix = { version = "0.27", features = ["ioctl"] }
 thiserror = "1.0.4"
-userfaultfd-sys = { path = "userfaultfd-sys", version = "^0.5.0" }
+userfaultfd-sys = { path = "userfaultfd-sys", version = "^0.5.0", default-features = false }
 
 [dev-dependencies]
 nix = { version = "0.27", features = ["poll", "mman", "feature"] }
 
 [features]
-default = []
+default = ["runtime"]
+
 linux4_14 = ["userfaultfd-sys/linux4_14", "nix/process"]
 linux5_7 = ["userfaultfd-sys/linux5_7"]
+
+runtime = ["userfaultfd-sys/runtime"]
+static = ["userfaultfd-sys/static"]

--- a/userfaultfd-sys/Cargo.toml
+++ b/userfaultfd-sys/Cargo.toml
@@ -13,10 +13,14 @@ build = "build.rs"
 cfg-if = "^1.0.0"
 
 [build-dependencies]
-bindgen = { version = "^0.68.1", default-features = false, features = ["runtime"]  }
+bindgen = { version = "^0.68.1", default-features = false }
 cc = "1.0"
 
 [features]
-default = []
+default = ["runtime"]
+
 linux4_14 = []
 linux5_7 = []
+
+runtime = ["bindgen/runtime"]
+static = ["bindgen/static"]


### PR DESCRIPTION
Currently both `userfaultfd` and `userfaultfd-sys` always load libclang dynamically. This commit keeps this as the default behavior but adds the "static" and "runtime" features. The "static" feature will statically link libclang, while "runtime" will load libclang at runtime.

Users using `default-features=false` will need to specify `features = ["runtime"]` to maintain current behavior, but they should be in the minority, given that neither crate currently has default features.