### PR TITLE
chore: prepare release 0.9.0 / 0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### 0.9.0
+
+- Add support for `UFFDIO_CONTINUE` and `UFFDIO_REGISTER_MODE_MINOR` under the new `linux5_13` feature.
+
 ### 0.8.0 (2024-01-12)
 
 - `IoctlFlags` accepts unknown flags (e.g. due to future kernel changes).

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "userfaultfd"
-version = "0.8.1"
+version = "0.9.0"
 authors = ["The Wasmtime Project Developers"]
 edition = "2018"
 license = "MIT OR Apache-2.0"
@@ -14,7 +14,7 @@ cfg-if = "^1.0.0"
 libc = "0.2.65"
 nix = { version = "0.27", features = ["ioctl"] }
 thiserror = "1.0.4"
-userfaultfd-sys = { path = "userfaultfd-sys", version = "^0.5.0" }
+userfaultfd-sys = { path = "userfaultfd-sys", version = "^0.6.0" }
 
 [dev-dependencies]
 nix = { version = "0.27", features = ["poll", "mman", "feature"] }

--- a/userfaultfd-sys/Cargo.toml
+++ b/userfaultfd-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "userfaultfd-sys"
-version = "0.5.0"
+version = "0.6.0"
 authors = ["The Wasmtime Project Developers"]
 edition = "2018"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
0.9.0 for the main crate, 0.6.0 for -sys.