### PR TITLE
Add copy_wp() method for UFFDIO_COPY with UFFDIO_COPY_MODE_WP

### DIFF
--- a/examples/manpage.rs
+++ b/examples/manpage.rs
@@ -64,7 +64,7 @@ fn fault_handler_thread(uffd: Uffd) {
             fault_cnt += 1;
 
             let dst = (addr as usize & !(page_size - 1)) as *mut c_void;
-            let copy = unsafe { uffd.copy(page, dst, page_size, true).expect("uffd copy") };
+            let copy = unsafe { uffd.copy(page, dst, page_size, false, true).expect("uffd copy") };
 
             println!("        (uffdio_copy.copy returned {})", copy);
         } else {


### PR DESCRIPTION
  - Add `copy_wp()` method that combines `UFFDIO_COPY` with `UFFDIO_COPY_MODE_WP` to resolve a page fault and enable write-protection tracking in a single ioctl call
  - Useful for dirty-page tracking scenarios where you want to resolve a missing-page fault while simultaneously enabling write-protection monitoring, avoiding a separate `write_protect()`
  call
  - Add `test_copy_wp` test validating the full missing-fault → copy+WP → write-protect-fault → remove-WP flow

  ## Test plan
  - [x] `cargo build --features linux5_7` compiles
  - [x] `cargo test --features linux5_7` — all 9 tests pass (5 unit, 1 integration, 3 doc-tests) on Linux 6.8
  - [x] New `test_copy_wp` verifies:
    1. Missing fault resolved with `copy_wp()` copies source data and sets WP in one ioctl
    2. Subsequent write triggers a write-protect fault
    3. After removing WP, the write lands successfully
