### PR TITLE
Ubuntu 20.04 runner image is no longer available

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -9,14 +9,10 @@ on:
 jobs:
   build:
 
-    # ubuntu-latest runs a recent kernel with /dev/userfaultfd support whereas
-    # ubuntu-20.04 has a 5.15 kernel. We run the job in both, so we can test
-    # both paths for creating the file descriptor, i.e. /dev/userfaultfd ioctl
-    # and userfaultfd syscall.
     runs-on: ${{ matrix.runner }}
     strategy:
       matrix:
-        runner: [ ubuntu-latest, ubuntu-20.04 ]
+        runner: [ ubuntu-latest, ubuntu-22.04 ]
 
     steps:
     - uses: actions/checkout@v2
@@ -28,7 +24,6 @@ jobs:
 
     # /dev/userfaultfd is only present on ubuntu-latest.
     - name: Setup access to /dev/userfaultfd
-      if: ${{ matrix.runner == 'ubuntu-latest' }}
       run: sudo setfacl -m u:${USER}:rw /dev/userfaultfd
 
     - name: Build
@@ -40,18 +35,7 @@ jobs:
       run: cargo test --verbose --features linux4_14
 
     - name: Run tests (Linux 5.7 support)
-      if: ${{ matrix.runner == 'ubuntu-latest' }}
       run: cargo test --verbose --features linux5_7
-
-    # On ubuntu-20.04 runner we need to make sure we have the proper kernel
-    # headers for building the correct bindings
-    - name: Run tests (Linux 5.7 support)
-      if: ${{ matrix.runner == 'ubuntu-20.04' }}
-      run:
-        sudo apt update &&
-        sudo apt install -y linux-headers-5.11.0-25-generic &&
-        export LINUX_HEADERS=/usr/src/linux-headers-5.11.0-25-generic &&
-        cargo test --verbose --features linux5_7
 
   audit:
 


### PR DESCRIPTION
Update to 22.04 instead, which is the oldest Ubuntu image available on GitHub Actions. Unfortunately this means we no longer test with an old kernel in CI, but at least it unbreaks the CI build.